### PR TITLE
Ignore CONNECTION_ERROR_WANTS_READ in receive_handler()

### DIFF
--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -262,7 +262,7 @@ void M2MConnectionHandlerPimpl::receive_handler(Socket */*socket*/)
         if(rcv_size >= 0){
             _observer.data_available((uint8_t*)_receive_buffer,
                                      rcv_size, *_socket_address);
-        }else{
+        } else if (M2MConnectionHandler::CONNECTION_ERROR_WANTS_READ != rcv_size) {
             _observer.socket_error(1);
             return;
         }

--- a/test/mbed-client-mbed-os/unittest/m2mconnectionhandlerpimpl_mbed/test_m2mconnectionhandlerpimpl_mbed.cpp
+++ b/test/mbed-client-mbed-os/unittest/m2mconnectionhandlerpimpl_mbed/test_m2mconnectionhandlerpimpl_mbed.cpp
@@ -188,6 +188,13 @@ void Test_M2MConnectionHandlerPimpl_mbed::test_receive_handler()
     handler->receive_handler(NULL);
     CHECK(observer->error == true);
 
+    observer->dataAvailable = false;
+    bserver->error = false;
+    m2mconnectionsecurityimpl_stub::int_value = M2MConnectionHandler::CONNECTION_ERROR_WANTS_READ;
+    handler->receive_handler(NULL);
+    CHECK(observer->error == false);
+    CHECK(observer->dataAvailable == false);
+
     handler->_binding_mode = M2MInterface::TCP;
     observer->dataAvailable = false;
     m2mconnectionsecurityimpl_stub::int_value = 5;

--- a/test/mbed-client-mbed-os/unittest/m2mconnectionhandlerpimpl_mbed/test_m2mconnectionhandlerpimpl_mbed.cpp
+++ b/test/mbed-client-mbed-os/unittest/m2mconnectionhandlerpimpl_mbed/test_m2mconnectionhandlerpimpl_mbed.cpp
@@ -189,7 +189,7 @@ void Test_M2MConnectionHandlerPimpl_mbed::test_receive_handler()
     CHECK(observer->error == true);
 
     observer->dataAvailable = false;
-    bserver->error = false;
+    observer->error = false;
     m2mconnectionsecurityimpl_stub::int_value = M2MConnectionHandler::CONNECTION_ERROR_WANTS_READ;
     handler->receive_handler(NULL);
     CHECK(observer->error == false);


### PR DESCRIPTION
This is required in order to work with 6LoWPAN stack.
mbedTLS already reads until socket is empty, so received onRead event
from Socket might still return that socket is empty.