### PR TITLE
m2mtimer: reduce object size by reorganizing the members

### DIFF
--- a/mbed-client-mbed-os/m2mtimerpimpl.h
+++ b/mbed-client-mbed-os/m2mtimerpimpl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 ARM Limited. All rights reserved.
+ * Copyright (c) 2015-2016 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the License); you may
  * not use this file except in compliance with the License.
@@ -89,17 +89,17 @@ private:
     bool is_total_interval_passed();
 
 private:
-    M2MTimerObserver&   _observer;
-    bool                _single_shot;
-    uint64_t            _interval;
-    M2MTimerObserver::Type  _type;
+    mbed::Ticker        _ticker;
 
+    uint64_t            _interval;
     uint64_t            _intermediate_interval;
     uint64_t            _total_interval;
-    uint8_t             _status;
     uint64_t            _still_left;
 
-    mbed::Ticker        _ticker;
+    M2MTimerObserver&   _observer;
+    M2MTimerObserver::Type  _type;
+    uint8_t             _status;
+    bool                _single_shot;
 
     friend class M2MTimer;
     friend class Test_M2MTimerPimpl_mbed;

--- a/source/m2mtimerpimpl.cpp
+++ b/source/m2mtimerpimpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 ARM Limited. All rights reserved.
+ * Copyright (c) 2015-2016 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the License); you may
  * not use this file except in compliance with the License.
@@ -17,14 +17,14 @@
 #include "mbed-client/m2mtimerobserver.h"
 
 M2MTimerPimpl::M2MTimerPimpl(M2MTimerObserver& observer)
-: _observer(observer),
-  _single_shot(true),
-  _interval(0),
-  _type(M2MTimerObserver::Notdefined),
+:  _interval(0),
   _intermediate_interval(0),
   _total_interval(0),
+  _still_left(0),
+  _observer(observer),
+  _type(M2MTimerObserver::Notdefined),
   _status(0),
-  _still_left(0)
+  _single_shot(true)
 {
 
 }

--- a/test/mbed-client-mbed-os/unittest/stub/m2mbase_stub.cpp
+++ b/test/mbed-client-mbed-os/unittest/stub/m2mbase_stub.cpp
@@ -308,3 +308,8 @@ const String& M2MBase::uri_path() const
 {
     return *m2mbase_stub::string_value;
 }
+
+bool M2MBase::is_under_observation() const
+{
+    return m2mbase_stub::bool_value;
+}


### PR DESCRIPTION
Reduce the RAM footprint of M2MTimerPimpl object from 112 bytes
to 86 bytes by reorganinzing the members. This allows compiler
to avoid adding padding between them.