### PR TITLE
Fix IPv6 address storing at M2MConnectionHandlerPimpl::dns_handler()

### DIFF
--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -294,7 +294,7 @@ void M2MConnectionHandlerPimpl::dns_handler(Socket */*socket*/, struct socket_ad
         *(uint32_t *)(_socket_address->_address) = sa.ipv6be[3];
     } else {
         _socket_address->_length = 16;
-        *(uint32_t *)(_socket_address->_address) = *sa.ipv6be;
+        memcpy(_socket_address->_address, sa.ipv6be, 16);
     }
 
     _socket_address->_stack = _network_stack;


### PR DESCRIPTION
The code stored only the topmost 32 bits of the resolved IPv6 address,
which is not good for functionality. Fix this by copying the whole
IPv6 address.

Fixes IOTCLT-752.